### PR TITLE
applications: nrf5340_audio: Use fork of sdk-zephyr

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -33,6 +33,8 @@ manifest:
       url-base: https://github.com/NordicSemiconductor
     - name: memfault
       url-base: https://github.com/memfault
+    - name: erikrobstad
+      url-base: https://github.com/erikrobstad
 
   # If not otherwise specified, the projects below should be obtained
   # from the ncs remote.
@@ -52,7 +54,8 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: a73fdfbe4d9293589ed26c356644d2e94c1fc54e
+      revision: 82d7eb4af2b2c4125b2c222f3a7dac5bd0bd4909
+      remote: erikrobstad
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
To be able to cherry-pick needed commits from
upstream Zephyr while implementing BAP

Signed-off-by: Erik Robstad <erik.robstad@nordicsemi.no>