### PR TITLE
Applications: nrf5340_audio: Get config from base_recv

### DIFF
--- a/applications/nrf5340_audio/src/audio/streamctrl.c
+++ b/applications/nrf5340_audio/src/audio/streamctrl.c
@@ -350,6 +350,14 @@ static void le_audio_evt_handler(enum le_audio_evt_type event)
 
 	case LE_AUDIO_EVT_CONFIG_RECEIVED:
 		LOG_INF("Config received");
+
+		int bitrate;
+		int sampling_rate;
+
+		le_audio_config_get(&bitrate, &sampling_rate);
+
+		LOG_DBG("Sampling rate: %d", sampling_rate);
+		LOG_DBG("Bitrate: %d", bitrate);
 		break;
 
 	default:

--- a/applications/nrf5340_audio/src/bluetooth/le_audio.h
+++ b/applications/nrf5340_audio/src/bluetooth/le_audio.h
@@ -34,12 +34,12 @@ typedef void (*le_audio_receive_cb)(const uint8_t *const data, size_t size, bool
 /**
  * @brief Get configuration for audio stream
  *
- * @param data	Data to send
- * @param size	Size of data to send
+ * @param bitrate	Pointer to bitrate used
+ * @param sampling_rate	Pointer to sampling rate used
  *
  * @return	0 for success, error otherwise
  */
-int le_audio_config_get(void);
+int le_audio_config_get(uint32_t *bitrate, uint32_t *sampling_rate);
 
 /**
  * @brief	Increase volume by one step

--- a/applications/nrf5340_audio/src/bluetooth/le_audio_bis_headset.c
+++ b/applications/nrf5340_audio/src/bluetooth/le_audio_bis_headset.c
@@ -36,6 +36,26 @@ static struct bt_audio_lc3_preset lc3_preset = BT_AUDIO_LC3_BROADCAST_PRESET_48_
 static const uint32_t bis_index_mask = BIT_MASK(ARRAY_SIZE(streams) + 1U);
 static uint32_t bis_index_bitfield;
 
+static void print_codec(const struct bt_codec *codec)
+{
+	if (codec->id == BT_CODEC_LC3_ID) {
+		/* LC3 uses the generic LTV format - other codecs might do as well */
+		uint32_t chan_allocation;
+
+		LOG_INF("Codec config for LC3:");
+		LOG_INF("\tFrequency: %d Hz", bt_codec_cfg_get_freq(codec));
+		LOG_INF("\tFrame Duration: %d us", bt_codec_cfg_get_frame_duration_us(codec));
+		if (bt_codec_cfg_get_chan_allocation_val(codec, &chan_allocation) == 0) {
+			LOG_INF("\tChannel allocation: 0x%x", chan_allocation);
+		}
+
+		LOG_INF("\tOctets per frame: %d", bt_codec_cfg_get_octets_per_frame(codec));
+		LOG_INF("\tFrames per SDU: %d", bt_codec_cfg_get_frame_blocks_per_sdu(codec, true));
+	} else {
+		LOG_INF("Codec is not LC3, codec_id: 0x%2x", codec->id);
+	}
+}
+
 static void stream_started_cb(struct bt_audio_stream *stream)
 {
 	int ret;
@@ -146,6 +166,8 @@ static void pa_sync_lost_cb(struct bt_audio_broadcast_sink *sink)
 
 static void base_recv_cb(struct bt_audio_broadcast_sink *sink, const struct bt_audio_base *base)
 {
+	int ret;
+	struct event_t event;
 	uint32_t base_bis_index_bitfield = 0U;
 
 	if (synced_to_broadcast) {
@@ -159,6 +181,13 @@ static void base_recv_cb(struct bt_audio_broadcast_sink *sink, const struct bt_a
 			const uint8_t index = base->subgroups[i].bis_data[j].index;
 
 			base_bis_index_bitfield |= BIT(index);
+			streams[i].codec = (struct bt_codec *)&base->subgroups[i].codec;
+			print_codec(streams[i].codec);
+			event.event_source = EVT_SRC_LE_AUDIO;
+			event.le_audio_activity.le_audio_evt_type = LE_AUDIO_EVT_CONFIG_RECEIVED;
+
+			ret = ctrl_events_put(&event);
+			ERR_CHK(ret);
 		}
 	}
 
@@ -196,8 +225,14 @@ static struct bt_audio_broadcast_sink_cb broadcast_sink_cbs = { .scan_recv = sca
 								.base_recv = base_recv_cb,
 								.syncable = syncable_cb };
 
-int le_audio_config_get(void)
+int le_audio_config_get(uint32_t *bitrate, uint32_t *sampling_rate)
 {
+	int frames_per_sec = 1000000 / bt_codec_cfg_get_frame_duration_us(streams[0].codec);
+	int bits_per_frame = bt_codec_cfg_get_octets_per_frame(streams[0].codec) * 8;
+
+	*sampling_rate = bt_codec_cfg_get_freq(streams[0].codec);
+	*bitrate = frames_per_sec * bits_per_frame;
+
 	return 0;
 }
 


### PR DESCRIPTION
- Parse codec config from base_recv_cb and copy into streams
- Create CONFIG_RECEIVED event and send to streamctrl
- Get bitrate and sampling rate from le_audio in streamctrl.c

Signed-off-by: Alexander Svensen <alexander.svensen@nordicsemi.no>