### PR TITLE
west.yml: Change to zephyr branch name in stead of hash

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -54,7 +54,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 82d7eb4af2b2c4125b2c222f3a7dac5bd0bd4909
+      revision: nrf5340_audio_implement_bap
       remote: erikrobstad
       import:
         # In addition to the zephyr repository itself, NCS also


### PR DESCRIPTION
This is just an intermediate solution for getting
cherry-picked commits until we can merge the
BAP implementation into NCS

Signed-off-by: Erik Robstad <erik.robstad@nordicsemi.no>