### PR TITLE
applications: nrf5340_audio: Implement atomic variable on gateways

### DIFF
--- a/applications/nrf5340_audio/src/bluetooth/le_audio_bis_gateway.c
+++ b/applications/nrf5340_audio/src/bluetooth/le_audio_bis_gateway.c
@@ -20,36 +20,57 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(bis_gateway, CONFIG_LOG_BLE_LEVEL);
 
-static struct bt_audio_lc3_preset lc3_preset = BT_AUDIO_LC3_BROADCAST_PRESET_48_4_1;
+BUILD_ASSERT(CONFIG_BT_AUDIO_BROADCAST_SRC_STREAM_COUNT <= 1,
+	     "Only one stream is currently supported");
+
+#define HCI_ISO_BUF_ALLOC_PER_CHAN 2
+
+/* For being able to dynamically define iso_tx_pools */
+#define NET_BUF_POOL_ITERATE(i, _)                                                                 \
+	NET_BUF_POOL_FIXED_DEFINE(iso_tx_pool_##i, HCI_ISO_BUF_ALLOC_PER_CHAN,                     \
+				  BT_ISO_SDU_BUF_SIZE(CONFIG_BT_ISO_TX_MTU), 8, NULL);
+#define NET_BUF_POOL_PTR_ITERATE(i, ...) IDENTITY(&iso_tx_pool_##i)
+LISTIFY(CONFIG_BT_ISO_MAX_CHAN, NET_BUF_POOL_ITERATE, (;))
+
+/* clang-format off */
+static struct net_buf_pool *iso_tx_pools[] = { LISTIFY(CONFIG_BT_ISO_MAX_CHAN,
+						       NET_BUF_POOL_PTR_ITERATE, (,)) };
+/* clang-format on */
 
 static struct bt_audio_broadcast_source *broadcast_source;
 
-BUILD_ASSERT(CONFIG_BT_AUDIO_BROADCAST_SRC_STREAM_COUNT <= 1,
-	     "Only one stream is currently supported");
 static struct bt_audio_stream streams[CONFIG_BT_AUDIO_BROADCAST_SRC_STREAM_COUNT];
 
-NET_BUF_POOL_FIXED_DEFINE(tx_pool, CONFIG_BT_AUDIO_BROADCAST_SRC_STREAM_COUNT,
-			  BT_ISO_SDU_BUF_SIZE(CONFIG_BT_ISO_TX_MTU), 8, NULL);
+static struct bt_audio_lc3_preset lc3_preset = BT_AUDIO_LC3_BROADCAST_PRESET_48_4_1;
 
-static uint32_t send_req_cnt;
-static uint32_t sent_cnt;
+static atomic_t iso_tx_pool_alloc[CONFIG_BT_ISO_MAX_CHAN];
 static bool delete_broadcast_src;
+
+static bool is_iso_buffer_full(uint8_t idx)
+{
+	/* net_buf_alloc allocates buffers for APP->NET transfer over HCI RPMsg,
+	 * but when these buffers are released it is not guaranteed that the
+	 * data has actually been sent. The data might be qued on the NET core,
+	 * and this can cause delays in the audio.
+	 * When stream_sent_cb() is called the data has been sent.
+	 * Data will be discarded if allocation becomes too high, to avoid audio delays.
+	 * If the NET and APP core operates in clock sync, discarding should not occur.
+	 */
+
+	if (atomic_get(&iso_tx_pool_alloc[idx]) >= HCI_ISO_BUF_ALLOC_PER_CHAN) {
+		return true;
+	}
+
+	return false;
+}
 
 static void stream_sent_cb(struct bt_audio_stream *stream)
 {
-	int32_t diff;
+	static uint32_t sent_cnt;
+
+	atomic_dec(&iso_tx_pool_alloc[0]);
 
 	sent_cnt++;
-
-	diff = send_req_cnt - sent_cnt;
-
-	// TODO: Use the atomic functionality from ble_trans
-	// if (diff < 0) {
-	// 	/* Should not happen */
-	// 	LOG_WRN("Sending underrun");
-	// } else if (diff > 0) {
-	// 	LOG_WRN("Sending overrun");
-	// }
 
 	if ((sent_cnt % 1000U) == 0U) {
 		LOG_INF("Sent %u total ISO packets", sent_cnt);
@@ -72,6 +93,8 @@ static void stream_stopped_cb(struct bt_audio_stream *stream)
 
 	ret = ctrl_events_le_audio_event_send(LE_AUDIO_EVT_NOT_STREAMING);
 	ERR_CHK(ret);
+
+	atomic_clear(&iso_tx_pool_alloc[0]);
 
 	LOG_INF("Broadcast source stopped");
 
@@ -134,26 +157,41 @@ int le_audio_volume_mute(void)
 
 int le_audio_play(void)
 {
-	return ctrl_events_le_audio_event_send(LE_AUDIO_EVT_STREAMING);
+	stream_started_cb(&streams[0]);
+	return 0;
 }
 
 int le_audio_pause(void)
 {
-	return ctrl_events_le_audio_event_send(LE_AUDIO_EVT_NOT_STREAMING);
+	stream_stopped_cb(&streams[0]);
+	return 0;
 }
 
 int le_audio_send(uint8_t const *const data, size_t size)
 {
 	int ret;
+	static bool wrn_printed[CONFIG_BT_ISO_MAX_CHAN];
 	struct net_buf *buf;
 
 	if (streams[0].ep->status.state != BT_AUDIO_EP_STATE_STREAMING) {
 		return -ECANCELED;
 	}
 
-	buf = net_buf_alloc(&tx_pool, K_FOREVER);
+	if (is_iso_buffer_full(0)) {
+		if (!wrn_printed[0]) {
+			LOG_WRN("HCI ISO TX overrun on ch %d - Single print", 0);
+			wrn_printed[0] = true;
+		}
+
+		return -ENOMEM;
+	}
+
+	wrn_printed[0] = false;
+
+	buf = net_buf_alloc(iso_tx_pools[0], K_NO_WAIT);
 	if (buf == NULL) {
-		LOG_WRN("Could not allocate buffer when sending");
+		/* This should never occur because of the is_iso_buffer_full() check */
+		LOG_WRN("Out of TX buffers");
 		return -ENOMEM;
 	}
 
@@ -172,13 +210,15 @@ int le_audio_send(uint8_t const *const data, size_t size)
 	}
 #endif
 
-	ret = bt_audio_stream_send(streams, buf);
+	atomic_inc(&iso_tx_pool_alloc[0]);
+
+	ret = bt_audio_stream_send(&streams[0], buf);
 	if (ret < 0) {
+		LOG_WRN("Failed to send audio data: %d", ret);
 		net_buf_unref(buf);
+		atomic_dec(&iso_tx_pool_alloc[0]);
 		return ret;
 	}
-
-	send_req_cnt++;
 
 	return 0;
 }

--- a/applications/nrf5340_audio/src/bluetooth/le_audio_bis_headset.c
+++ b/applications/nrf5340_audio/src/bluetooth/le_audio_bis_headset.c
@@ -20,13 +20,11 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(bis_headset, CONFIG_LOG_BLE_LEVEL);
 
-static le_audio_receive_cb receive_cb;
-static bool init_routine_completed;
+BUILD_ASSERT(CONFIG_BT_AUDIO_BROADCAST_SNK_STREAM_COUNT <= 1,
+	     "Only one stream is currently supported");
 
 static struct bt_audio_broadcast_sink *broadcast_sink;
 
-BUILD_ASSERT(CONFIG_BT_AUDIO_BROADCAST_SNK_STREAM_COUNT <= 1,
-	     "Only one stream is currently supported");
 static struct bt_audio_stream streams[CONFIG_BT_AUDIO_BROADCAST_SNK_STREAM_COUNT];
 
 static struct bt_audio_lc3_preset lc3_preset = BT_AUDIO_LC3_BROADCAST_PRESET_48_4_1;
@@ -37,6 +35,9 @@ static struct bt_audio_lc3_preset lc3_preset = BT_AUDIO_LC3_BROADCAST_PRESET_48_
  */
 static const uint32_t bis_index_mask = BIT_MASK(ARRAY_SIZE(streams) + 1U);
 static uint32_t bis_index_bitfield;
+
+static le_audio_receive_cb receive_cb;
+static bool init_routine_completed;
 
 static int bis_headset_cleanup(bool from_sync_lost_cb);
 


### PR DESCRIPTION
To check for sending overruns.
Both CIS and BIS gateway.

Signed-off-by: Erik Robstad <erik.robstad@nordicsemi.no>