### PR TITLE
applications: nrf5340_audio: Set PACS available contexts properly

### DIFF
--- a/applications/nrf5340_audio/src/bluetooth/le_audio_cis_gateway.c
+++ b/applications/nrf5340_audio/src/bluetooth/le_audio_cis_gateway.c
@@ -135,7 +135,7 @@ static void add_remote_sink(struct bt_audio_ep *ep, uint8_t index)
 
 static void add_remote_codec(struct bt_codec *codec, int index, uint8_t type)
 {
-	if (type != BT_AUDIO_SINK && type != BT_AUDIO_SOURCE) {
+	if (type != BT_AUDIO_DIR_SINK && type != BT_AUDIO_DIR_SOURCE) {
 		return;
 	}
 
@@ -155,15 +155,15 @@ static void discover_sink_cb(struct bt_conn *conn, struct bt_codec *codec, struc
 	}
 
 	if (codec != NULL) {
-		add_remote_codec(codec, params->num_caps, params->type);
+		add_remote_codec(codec, params->num_caps, params->dir);
 		return;
 	}
 
 	if (ep != NULL) {
-		if (params->type == BT_AUDIO_SINK) {
+		if (params->dir == BT_AUDIO_DIR_SINK) {
 			add_remote_sink(ep, params->num_eps);
 		} else {
-			LOG_ERR("Invalid param type: %u", params->type);
+			LOG_ERR("Invalid param type: %u", params->dir);
 		}
 
 		return;
@@ -313,7 +313,7 @@ static void security_changed_cb(struct bt_conn *conn, bt_security_t level, enum 
 		static struct bt_audio_discover_params dis_params;
 
 		dis_params.func = discover_sink_cb;
-		dis_params.type = BT_AUDIO_SINK;
+		dis_params.dir = BT_AUDIO_DIR_SINK;
 
 		ret = bt_audio_discover(default_conn, &dis_params);
 		if (ret) {

--- a/applications/nrf5340_audio/src/bluetooth/le_audio_cis_headset.c
+++ b/applications/nrf5340_audio/src/bluetooth/le_audio_cis_headset.c
@@ -38,10 +38,9 @@ static const struct bt_data ad[] = {
 static struct bt_audio_capability_ops lc3_cap_codec_ops;
 static struct bt_codec lc3_codec =
 	BT_CODEC_LC3(BT_CODEC_LC3_FREQ_ANY, BT_CODEC_LC3_DURATION_10, CHANNEL_COUNT_1, 40u, 120u,
-		     1u, (BT_AUDIO_CONTEXT_TYPE_CONVERSATIONAL | BT_AUDIO_CONTEXT_TYPE_MEDIA),
-		     BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED);
+		     1u, BT_AUDIO_CONTEXT_TYPE_MEDIA, BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED);
 static struct bt_audio_capability caps = {
-	.type = BT_AUDIO_SINK,
+	.dir = BT_AUDIO_DIR_SINK,
 	.pref = BT_AUDIO_CAPABILITY_PREF(
 		BT_AUDIO_CAPABILITY_UNFRAMED_SUPPORTED, BT_GAP_LE_PHY_2M, BLE_ISO_RETRANSMITS,
 		BLE_ISO_LATENCY_MS, BLE_ISO_PRSENTATION_DELAY_MIN_US,
@@ -74,7 +73,7 @@ static void print_codec(const struct bt_codec *codec)
 }
 
 static struct bt_audio_stream *lc3_cap_config_cb(struct bt_conn *conn, struct bt_audio_ep *ep,
-						 enum bt_audio_pac_type type,
+						 enum bt_audio_dir dir,
 						 struct bt_audio_capability *cap,
 						 struct bt_codec *codec)
 {
@@ -258,11 +257,21 @@ static int initialize(le_audio_receive_cb recv_cb)
 			LOG_ERR("Capability register failed");
 			return ret;
 		}
-		ret = bt_audio_capability_set_location(BT_AUDIO_SINK, BT_AUDIO_LOCATION_SIDE_LEFT);
+		ret = bt_audio_capability_set_location(BT_AUDIO_DIR_SINK,
+						       BT_AUDIO_LOCATION_SIDE_LEFT);
 		if (ret) {
 			LOG_ERR("Location set failed");
 			return ret;
 		}
+
+		ret = bt_audio_capability_set_available_contexts(
+			BT_AUDIO_DIR_SINK,
+			BT_AUDIO_CONTEXT_TYPE_MEDIA | BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED);
+		if (ret) {
+			LOG_ERR("Available contexte set failed");
+			return ret;
+		}
+
 		bt_audio_stream_cb_register(&audio_stream, &stream_ops);
 		initialized = true;
 	}


### PR DESCRIPTION
Cherry-pick bug fixes for PACS in Zephyr, set PACS available
contexts in application instead of using Kconfig

Signed-off-by: Jui-Chou Chung <jui-chou.chung@nordicsemi.no>