### PR TITLE
applications: nrf5340_audio: Update sdu_ref for CIS I2S gateway

### DIFF
--- a/applications/nrf5340_audio/src/audio/audio_datapath.c
+++ b/applications/nrf5340_audio/src/audio/audio_datapath.c
@@ -242,8 +242,10 @@ static void audio_datapath_drift_compensation(uint32_t frame_start_ts)
 			return;
 		}
 
-		int32_t err_us = DRIFT_MEAS_PERIOD_US - (ctrl_blk.previous_sdu_ref_us -
-							 ctrl_blk.drift_comp.meas_start_time_us);
+		int32_t err_us = (DRIFT_MEAS_PERIOD_US - (ctrl_blk.previous_sdu_ref_us -
+							  ctrl_blk.drift_comp.meas_start_time_us)) %
+				 CONFIG_AUDIO_FRAME_DURATION_US;
+
 		int32_t freq_adj = APLL_FREQ_ADJ(err_us);
 
 		ctrl_blk.drift_comp.center_freq = APLL_FREQ_CENTER + freq_adj;

--- a/applications/nrf5340_audio/src/audio/streamctrl.c
+++ b/applications/nrf5340_audio/src/audio/streamctrl.c
@@ -210,8 +210,6 @@ uint8_t stream_state_get(void)
 
 void streamctrl_encoded_data_send(void const *const data, size_t len)
 {
-	// TODO: Re-implement the I2S gateway synchronization functionality
-
 	int ret;
 	static int prev_ret;
 


### PR DESCRIPTION
Making the I2S speed same as the BLE traffic speed.

Added '% CONFIG_AUDIO_FRAME_DURATION_US' to drift_compensation
STATE_CALIB err_us calculation in case ctrl_blk.previous_sdu_ref_us
is not updated before err_us is calculated.

Signed-off-by: Erik Robstad <erik.robstad@nordicsemi.no>