### PR TITLE
applications: nrf5340_audio: Fix bug in hw_codec_volume_adjust()

### DIFF
--- a/applications/nrf5340_audio/src/modules/hw_codec.c
+++ b/applications/nrf5340_audio/src/modules/hw_codec.c
@@ -118,7 +118,7 @@ int hw_codec_volume_adjust(int8_t adjustment)
 	 */
 	adjustment *= 2;
 
-	uint16_t volume_reg_val;
+	int16_t volume_reg_val;
 
 	ret = cs47l63_read_reg(&cs47l63_driver, CS47L63_OUT1L_VOLUME_1,
 			       (uint32_t *)&volume_reg_val);


### PR DESCRIPTION
So that volume does not go from MIN
to MAX when calling hw_codec_volume_decrease()
when volume is close to 0

Signed-off-by: Erik Robstad <erik.robstad@nordicsemi.no>