### PR TITLE
applications: nrf5340_audio: Fix BIS issue after upmerge

### DIFF
--- a/applications/nrf5340_audio/src/bluetooth/le_audio_bis_gateway.c
+++ b/applications/nrf5340_audio/src/bluetooth/le_audio_bis_gateway.c
@@ -38,6 +38,7 @@ static struct net_buf_pool *iso_tx_pools[] = { LISTIFY(CONFIG_BT_ISO_MAX_CHAN,
 static struct bt_audio_broadcast_source *broadcast_source;
 
 static struct bt_audio_stream streams[CONFIG_BT_AUDIO_BROADCAST_SRC_STREAM_COUNT];
+static struct bt_audio_stream *streams_p[ARRAY_SIZE(streams)];
 
 static struct bt_audio_lc3_preset lc3_preset = BT_AUDIO_LC3_BROADCAST_PRESET_48_4_1;
 
@@ -124,6 +125,7 @@ static void initialize(void)
 
 	if (!initialized) {
 		for (size_t i = 0U; i < ARRAY_SIZE(streams); i++) {
+			streams_p[i] = &streams[i];
 			streams[i].ops = &stream_ops;
 		}
 
@@ -243,7 +245,7 @@ int le_audio_enable(le_audio_receive_cb recv_cb)
 
 	LOG_INF("Creating broadcast source");
 
-	ret = bt_audio_broadcast_source_create(streams, ARRAY_SIZE(streams), &lc3_preset.codec,
+	ret = bt_audio_broadcast_source_create(streams_p, ARRAY_SIZE(streams_p), &lc3_preset.codec,
 					       &lc3_preset.qos, &broadcast_source);
 	if (ret) {
 		return ret;

--- a/applications/nrf5340_audio/src/bluetooth/le_audio_bis_headset.c
+++ b/applications/nrf5340_audio/src/bluetooth/le_audio_bis_headset.c
@@ -24,6 +24,7 @@ BUILD_ASSERT(CONFIG_BT_AUDIO_BROADCAST_SNK_STREAM_COUNT <= 1,
 static struct bt_audio_broadcast_sink *broadcast_sink;
 
 static struct bt_audio_stream streams[CONFIG_BT_AUDIO_BROADCAST_SNK_STREAM_COUNT];
+static struct bt_audio_stream *streams_p[ARRAY_SIZE(streams)];
 
 static struct bt_audio_lc3_preset lc3_preset = BT_AUDIO_LC3_BROADCAST_PRESET_48_4_1;
 
@@ -204,7 +205,7 @@ static void syncable_cb(struct bt_audio_broadcast_sink *sink, bool encrypted)
 
 	LOG_INF("Syncing to broadcast");
 
-	ret = bt_audio_broadcast_sink_sync(broadcast_sink, bis_index_bitfield, streams,
+	ret = bt_audio_broadcast_sink_sync(broadcast_sink, bis_index_bitfield, streams_p,
 					   &lc3_preset.codec, NULL);
 	if (ret) {
 		LOG_ERR("Unable to sync to broadcast source");
@@ -231,6 +232,7 @@ static void initialize(le_audio_receive_cb recv_cb)
 		bt_audio_broadcast_sink_register_cb(&broadcast_sink_cbs);
 
 		for (size_t i = 0U; i < ARRAY_SIZE(streams); i++) {
+			streams_p[i] = &streams[i];
 			streams[i].ops = &stream_ops;
 		}
 
@@ -309,7 +311,7 @@ int le_audio_volume_mute(void)
 
 int le_audio_play(void)
 {
-	return bt_audio_broadcast_sink_sync(broadcast_sink, bis_index_bitfield, streams,
+	return bt_audio_broadcast_sink_sync(broadcast_sink, bis_index_bitfield, streams_p,
 					    &lc3_preset.codec, NULL);
 }
 


### PR DESCRIPTION
Some bt_audio_(...) functions changed
to use stream pointer array

Signed-off-by: Erik Robstad <erik.robstad@nordicsemi.no>