### PR TITLE
applications: nrf5340_audio: Fix drift state name bug

### DIFF
--- a/applications/nrf5340_audio/src/audio/audio_datapath.c
+++ b/applications/nrf5340_audio/src/audio/audio_datapath.c
@@ -255,7 +255,7 @@ static void audio_datapath_drift_compensation(uint32_t frame_start_ts)
 		if ((ctrl_blk.drift_comp.center_freq > (APLL_FREQ_MAX)) ||
 		    (ctrl_blk.drift_comp.center_freq < (APLL_FREQ_MIN))) {
 			LOG_DBG("Invalid center frequency, re-calculating");
-			drift_comp_state_set(DRFT_STATE_INIT);
+			drift_comp_state_set(DRIFT_STATE_INIT);
 		}
 
 		hfclkaudio_set(ctrl_blk.drift_comp.center_freq);
@@ -304,7 +304,7 @@ static void audio_datapath_drift_compensation(uint32_t frame_start_ts)
 		hfclkaudio_set(ctrl_blk.drift_comp.center_freq + freq_adj);
 
 		if ((err_us > DRIFT_ERR_THRESH_UNLOCK) || (err_us < -DRIFT_ERR_THRESH_UNLOCK)) {
-			drift_comp_state_set(DRFT_STATE_INIT);
+			drift_comp_state_set(DRIFT_STATE_INIT);
 		} else {
 			ctrl_blk.drift_comp.ctr = 0;
 		}


### PR DESCRIPTION
Happened after rebase, DRFT = DRIFT

Signed-off-by: Erik Robstad <erik.robstad@nordicsemi.no>